### PR TITLE
Freeze dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,16 @@
 *.pyc
 __pycache__
-src/*.egg-info
+/src/*.egg-info
 .installed.cfg
-bin
-coverage
-develop-eggs
-keys/
-parts/
-include/
-lib/
-local/
+/bin/
+/coverage/
+/develop-eggs/
+/eggs/
+/keys/
+/parts/
+/include/
+/lib/
+/local/
 
 # Test data
 datakey.dat

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__
 /include/
 /lib/
 /local/
+# ignore virtualenv if used
+/ve/
 
 # Test data
 datakey.dat

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ parts = test coverage-test coverage-report python paster runserver testclient
         ctags
 versions = versions
 newest = true
+extends = versions.cfg
 
 [test]
 recipe = zc.recipe.testrunner
@@ -47,5 +48,3 @@ initialization =
 [testclient]
 recipe = zc.recipe.egg
 eggs = keas.kmi
-
-[versions]

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,231 @@
+# update versions via: bin/buildout update-versions-file=versions.cfg
+[versions]
+# Added by buildout at 2017-06-08 11:05:15.251238
+PasteDeploy = 1.5.2
+WebOb = 1.7.2
+WebTest = 2.0.27
+asn1crypto = 0.22.0
+cffi = 1.10.0
+coverage = 4.4.1
+cryptography = 1.9
+gunicorn = 19.7.1
+idna = 2.5
+pyOpenSSL = 17.0.0
+pyramid-zcml = 1.1.0
+pytz = 2017.2
+repoze.lru = 0.6
+translationstring = 1.3
+venusian = 1.1.0
+waitress = 1.0.2
+z3c.coverage = 2.1.0
+z3c.recipe.tag = 0.8
+zc.buildout = 2.9.3
+zc.recipe.egg = 2.0.3
+zc.recipe.testrunner = 2.0.0
+zodbpickle = 0.6.0
+zope.app.appsetup = 4.0.0
+zope.app.testing = 3.10.0
+zope.component = 4.3.0
+zope.configuration = 4.1.0
+zope.contenttype = 4.2.0
+zope.deprecation = 4.2.0
+zope.location = 4.0.3
+zope.session = 4.1.0
+zope.testbrowser = 5.2
+
+# Required by:
+# zope.container==4.1.0
+BTrees = 4.4.1
+
+# Required by:
+# zope.testbrowser==5.2
+WSGIProxy2 = 0.4.4
+
+# Required by:
+# ZODB==5.2.4
+# zdaemon==4.2.0
+ZConfig = 3.1.0
+
+# Required by:
+# zope.app.appsetup==4.0.0
+ZODB = 5.2.4
+
+# Required by:
+# WebTest==2.0.27
+beautifulsoup4 = 4.6.0
+
+# Required by:
+# pyramid==1.8.3
+hupper = 1.0
+
+# Required by:
+# zope.container==4.1.0
+persistent = 4.2.4.2
+
+# Required by:
+# cffi==1.10.0
+pycparser = 2.17
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+pycrypto = 2.6.1
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+pyramid = 1.8.3
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+# zope.testrunner==4.7.0
+six = 1.10.0
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+transaction = 2.1.2
+
+# Required by:
+# ZODB==5.2.4
+zc.lockfile = 1.2.1
+
+# Required by:
+# zope.app.appsetup==4.0.0
+zdaemon = 4.2.0
+
+# Required by:
+# zope.app.dependable==4.0.0
+# zope.app.testing==3.10.0
+# zope.site==4.0.0
+zope.annotation = 4.5
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.app.debug = 4.0.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.app.dependable = 4.0.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.app.publication = 4.2.1
+
+# Required by:
+# zope.app.publication==4.2.1
+zope.authentication = 4.3
+
+# Required by:
+# zope.publisher==4.3.2
+zope.browser = 2.1.0
+
+# Required by:
+# zope.testbrowser==5.2
+zope.cachedescriptors = 4.2.0
+
+# Required by:
+# zope.app.testing==3.10.0
+# zope.site==4.0.0
+zope.container = 4.1.0
+
+# Required by:
+# zope.container==4.1.0
+zope.dottedname = 4.2
+
+# Required by:
+# zope.app.appsetup==4.0.0
+# zope.app.publication==4.2.1
+zope.error = 4.3.0
+
+# Required by:
+# zope.app.appsetup==4.0.0
+# zope.component==4.3.0
+# zope.container==4.1.0
+# zope.publisher==4.3.2
+# zope.schema==4.4.2
+# zope.site==4.0.0
+zope.event = 4.2.0
+
+# Required by:
+# zope.testrunner==4.7.0
+zope.exceptions = 4.1.0
+
+# Required by:
+# zope.container==4.1.0
+zope.filerepresentation = 4.1.0
+
+# Required by:
+# zope.app.testing==3.10.0
+# zope.traversing==4.1.0
+zope.i18n = 4.2.0
+
+# Required by:
+# zope.app.dependable==4.0.0
+# zope.configuration==4.1.0
+# zope.container==4.1.0
+# zope.i18n==4.2.0
+# zope.security==4.1.1
+# zope.traversing==4.1.0
+zope.i18nmessageid = 4.1.0
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+# zope.testrunner==4.7.0
+zope.interface = 4.4.1
+
+# Required by:
+# zope.app.dependable==4.0.0
+# zope.site==4.0.0
+zope.lifecycleevent = 4.1.0
+
+# Required by:
+# zope.session==4.1.0
+zope.minmax = 2.1.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.password = 4.2.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.processlifetime = 2.1.0
+
+# Required by:
+# zope.annotation==4.5
+# zope.publisher==4.3.2
+# zope.traversing==4.1.0
+zope.proxy = 4.2.1
+
+# Required by:
+# zope.app.testing==3.10.0
+# zope.traversing==4.1.0
+zope.publisher = 4.3.2
+
+# Required by:
+# keas.kmi==3.2.1.dev0
+# zope.app.testing==3.10.0
+zope.schema = 4.4.2
+
+# Required by:
+# zope.app.testing==3.10.0
+# zope.site==4.0.0
+# zope.traversing==4.1.0
+zope.security = 4.1.1
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.site = 4.0.0
+
+# Required by:
+# zope.container==4.1.0
+zope.size = 4.1.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.testing = 4.6.1
+
+# Required by:
+# zc.recipe.testrunner==2.0.0
+zope.testrunner = 4.7.0
+
+# Required by:
+# zope.app.testing==3.10.0
+zope.traversing = 4.1.0


### PR DESCRIPTION
Freeze dependencies via `[versions]` for reproducible builds.

Also added things that appeared to be missing from `.gitignore`, and made the ignore statements more specific